### PR TITLE
[LLT-5312] Add more logging when read from tun failure happens

### DIFF
--- a/device/send.go
+++ b/device/send.go
@@ -10,7 +10,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"net"
-	"os"
 	"sync"
 	"time"
 
@@ -310,9 +309,7 @@ func (device *Device) RoutineReadFromTUN() {
 				continue
 			}
 			if !device.isClosed() {
-				if !errors.Is(readErr, os.ErrClosed) {
-					device.log.Errorf("Failed to read packet from TUN device: %v", readErr)
-				}
+				device.log.Errorf("Failed to read packet from TUN device: %v", readErr)
 				go device.Close()
 			}
 			return


### PR DESCRIPTION
During nightly tests on job 13830453 windows has failed to create wintun/wg-go adapter. And the test failed. After some investigation it seems like the tunnel is being destructed from within itself.

The only feasible place where this could happen seems to be here: https://github.com/NordSecurity/wireguard-go/blob/v0.0.2/device/send.go#L316, which is triggered by receiving error while reading from tunnel. In order to guide the investigation further, it would be nice to figure our exactly which error occurs, and thus this PR adds some more detailed logs.
